### PR TITLE
Changed command_list_item_focused to command_list_item_selected

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -813,7 +813,7 @@ setup_hook(#in{key=Key, wx=Ctrl, type=dirpicker, hook=UserHook}, Fields) ->
 				       end}]),
     UserHook(Key, wxDirPickerCtrl:getPath(Ctrl), Fields);
 setup_hook(#in{key=Key, wx=Ctrl, type=table, hook=UserHook}, Fields) ->
-    wxListCtrl:connect(Ctrl, command_list_item_focused,
+    wxListCtrl:connect(Ctrl, command_list_item_selected,
         [{callback, fun(_, _) ->
             UserHook(Key, Ctrl, Fields)
         end}]),


### PR DESCRIPTION
command_list_item_focused I'm not able to get the selection in the table as I think the focus event happens before the control changes its selection state.

Changing it to command_list_item_selected fixes it and a wings_dialog:get_value() call in the hook function can now get the up to date selection.
